### PR TITLE
Fixed switch theme bug when changing to first theme.

### DIFF
--- a/Source/ThemeManager.cs
+++ b/Source/ThemeManager.cs
@@ -42,7 +42,7 @@ namespace Dodo.BlazorThemeSwitcher
         public string SwitchTheme(string theme)
         {
             int i = Array.IndexOf(Themes, theme);
-            if (i > 0)
+            if (i => 0)
             {
                 _currentThemeIndex = i;
             }


### PR DESCRIPTION
When trying to switch to the first theme at index 0 using SwitchTheme(string theme) the function will return the error Theme is not found. This fix alows setting the first theme at index 0.